### PR TITLE
Add light-sleep to save power.

### DIFF
--- a/buildserver-monitor/Application.cpp
+++ b/buildserver-monitor/Application.cpp
@@ -184,9 +184,10 @@ void Application::HandleSleeping()
 {
     mLogger.Log(LogLevel::INFO, "Handling Sleeping");
 
-    mLeds.SetColor(1, LedColor::Yellow);
-    delay(FIVE_SECONDS);
-    mLeds.SetColor(LedColor::Off);
+//    mLeds.SetColor(1, LedColor::Yellow);
+//    delay(FIVE_SECONDS);
+    delay(ONE_MINUTE);
+//    mLeds.SetColor(LedColor::Off);
 
     mSM.SetState(State::Idle);
 }
@@ -220,7 +221,7 @@ bool Application::TryConnect()
 {
     mLogger.Log(LogLevel::INFO, "Trying to connect...");
 
-    mLeds.SetColor(2, LedColor::Purple);
+//    mLeds.SetColor(2, LedColor::Purple);
 
     bool isConnected = mWifi.IsConnected();
     
@@ -229,7 +230,7 @@ bool Application::TryConnect()
         isConnected = mWifi.Connect(WIFI_CONNECTION_TIMEOUT);   // Can take some time (seconds)!
     }
 
-    mLeds.SetColor(LedColor::Off);
+//    mLeds.SetColor(LedColor::Off);
     
     return isConnected;
 }
@@ -242,12 +243,12 @@ bool Application::TryAcquiring()
 {
     mLogger.Log(LogLevel::INFO, "Trying to acquire...");
 
-    mLeds.SetColor(3, LedColor::Blue);
-    delay(ONE_SECOND);
+//    mLeds.SetColor(3, LedColor::Blue);
+//    delay(ONE_SECOND);
 
     bool result = mHttp.Acquire();
         
-    mLeds.SetColor(LedColor::Off);
+//    mLeds.SetColor(LedColor::Off);
 
     return result;
 }
@@ -260,15 +261,15 @@ bool Application::TryParsing()
 {
     mLogger.Log(LogLevel::INFO, "Trying to parse...");
 
-    mLeds.SetColor(4, LedColor::Red);
-    delay(ONE_SECOND);
+//    mLeds.SetColor(4, LedColor::Red);
+//    delay(ONE_SECOND);
 
     bool result = mHttp.Parse();
     if (!result) { return false; }
 
     mBuildState = mHttp.getBuildState();
     
-    mLeds.SetColor(LedColor::Off);
+//    mLeds.SetColor(LedColor::Off);
 
     return result;
 }
@@ -293,8 +294,8 @@ bool Application::TryDisplaying()
             mLogger.Log(LogLevel::ERROR, "Invalid BuildState!"); 
             break;
     }
-    delay(ONE_SECOND);
-    mLeds.SetColor(LedColor::Off);
+//    delay(ONE_SECOND);
+//    mLeds.SetColor(LedColor::Off);
 
     mBuildState = BuildState::NoState;
 

--- a/buildserver-monitor/WifiConnection.cpp
+++ b/buildserver-monitor/WifiConnection.cpp
@@ -173,6 +173,7 @@ bool WifiConnection::CheckValidSSIDAndPassword(const char* ssid, const char* pas
 bool WifiConnection::ConnectionAttempt(uint32_t timeout_ms)
 {
     WiFi.mode(WIFI_STA);
+    wifi_set_sleep_type(LIGHT_SLEEP_T);
     WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
 
     if (!WiFi.isConnected())

--- a/buildserver-monitor/timings.hpp
+++ b/buildserver-monitor/timings.hpp
@@ -29,18 +29,20 @@
 /* Configurable options                                                 */
 /************************************************************************/
 // Timeouts - in milliseconds
-static constexpr unsigned ONE_SECOND    =  1000;
-static constexpr unsigned TWO_SECONDS   =  2000;
-static constexpr unsigned THREE_SECONDS =  3000;
-static constexpr unsigned FOUR_SECONDS  =  4000;
-static constexpr unsigned FIVE_SECONDS  =  5000;
-static constexpr unsigned TEN_SECONDS   = 10000;
-static constexpr unsigned SIXTY_SECONDS = 60000;
+static constexpr unsigned ONE_SECOND     =  1000;
+static constexpr unsigned TWO_SECONDS    =  2000;
+static constexpr unsigned THREE_SECONDS  =  3000;
+static constexpr unsigned FOUR_SECONDS   =  4000;
+static constexpr unsigned FIVE_SECONDS   =  5000;
+static constexpr unsigned TEN_SECONDS    = 10000;
+static constexpr unsigned TWENTY_SECONDS = 20000;
+static constexpr unsigned THIRTY_SECONDS = 30000;
+static constexpr unsigned SIXTY_SECONDS  = 60000;
 
-static constexpr unsigned ONE_MINUTE    =  60000;
-static constexpr unsigned TWO_MINUTES   = 120000;
-static constexpr unsigned FIVE_MINUTES  = 300000;
-static constexpr unsigned TEN_MINUTES   = 600000;
+static constexpr unsigned ONE_MINUTE     =  60000;
+static constexpr unsigned TWO_MINUTES    = 120000;
+static constexpr unsigned FIVE_MINUTES   = 300000;
+static constexpr unsigned TEN_MINUTES    = 600000;
 
 
 #endif  // TIMINGS_HPP_


### PR DESCRIPTION
Add some extra timings for 20 and 30 seconds. Disable status display with leds when traversing through states to only show acquired build state (or error).